### PR TITLE
add function scanstream

### DIFF
--- a/Clamav.php
+++ b/Clamav.php
@@ -123,7 +123,7 @@ class Clamav {
                 }
                 $packet = pack("Nx",0);
                 socket_send($socket, $packet, strlen($packet), 0);
-                socket_recv($socket, $scan, $this->clamd_sock_len, 1);
+                socket_recv($socket, $scan, $this->clamd_sock_len, 0);
                 socket_close($socket);
                 trim($scan);
                 $scan = substr(strrchr($scan, ":"), 1);


### PR DESCRIPTION
Add support for clamd socket INSTREAM file scanning originally discussed here https://github.com/kissit/php-clamav-scan/issues/5#issuecomment-439321111.

Please note, I found that the code posted by @rvstaveren didn't actually report positives in files < 8192 bytes (tested with the EICAR test file). I've patched it to work correctly. 

As suggested, using scanstream works to get around the sandbox provided by [systemd's PrivateTmp directories](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=).

I've also verified that scanstream works via TCP socket with clamd running on a separate host. Note using it in this fashion will require the following SELinux change (use the -P option to setsebool to make the change permanent).
```
setsebool httpd_can_network_connect 1
```